### PR TITLE
Task/WIN-4: add prototype fastapi  app

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,3 @@
+[flake8]
+max-line-length = 88
+

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,22 @@
+## Overview
+
+
+
+## Related
+
+* [WIN-XYZ](https://tacc-main.atlassian.net/browse/WIN-XYZ)
+
+## Changes
+
+
+
+## Testing
+
+1.
+
+## UI
+
+
+
+## Notes
+

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,4 +28,4 @@ jobs:
         run: PYTHONPATH=. pytest tests
 
       - name: Run black check
-        run: make lint
+        run:  black --check . && flake8 .

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,31 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.13"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+
+      - name: Run tests
+        run: pytest tests
+
+      - name: Run black check
+        run: make lint

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
           pip install -r requirements.txt
 
       - name: Run tests
-        run: pytest tests
+        run: PYTHONPATH=. pytest tests
 
       - name: Run black check
         run: make lint

--- a/.gitignore
+++ b/.gitignore
@@ -172,3 +172,5 @@ cython_debug/
 
 # PyPI configuration file
 .pypirc
+
+.idea/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,22 @@
+FROM python:3.13-slim
+
+# Set working directory
+WORKDIR /app
+
+# Install system packages including vim
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    vim \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+WORKDIR /app
+
+COPY ./imageinf /app/imageinf
+COPY ./tests /app/tests
+
+ENV PYTHONPATH=/app
+
+CMD ["uvicorn", "imageinf.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,14 @@
-.PHONY: build start test lint
+.PHONY: build deploy start stop
+
+TAG := $(shell git log --format=%h -1)
+IMAGE=taccaci/imageinf
 
 build:
-	docker-compose build
+	docker build -t $(IMAGE):$(TAG) .
+	docker tag $(IMAGE):$(TAG) $(IMAGE):local
+
+deploy:
+	docker push $(IMAGE):$(TAG)
 
 start:
 	docker-compose up

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,7 @@
+.PHONY: build start
+
+build:
+	docker-compose build
+
+start:
+	docker-compose up

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,10 @@
-.PHONY: build start
+.PHONY: build start test lint
 
 build:
 	docker-compose build
 
 start:
 	docker-compose up
+
+stop:
+	docker-compose down

--- a/README.md
+++ b/README.md
@@ -7,17 +7,13 @@ image inferencing API
 ### Build
 
 ```bash
-
 make build
-
 ```
 
 ### Start
 
 ```bash
-
 make start
-
 ```
 
 Go to:  `http://localhost/status`

--- a/README.md
+++ b/README.md
@@ -1,2 +1,23 @@
 # imageInf
+
 image inferencing API
+
+## Usage
+
+### Build
+
+```bash
+
+make build
+
+```
+
+### Start
+
+```bash
+
+make start
+
+```
+
+Go to:  `http://localhost/status`

--- a/README.md
+++ b/README.md
@@ -21,3 +21,28 @@ make start
 ```
 
 Go to:  `http://localhost/status`
+
+
+## Development + Testing
+
+With the 'imageinf' service running via Docker, you can drop into the container to run tests and linting commands:
+
+```
+docker exec -it imageinf bash
+```
+
+### Run Tests
+```
+pytest tests
+```
+
+### Run Linting checks
+```
+black --check .
+flake8 .
+```
+
+Auto-fix formatting with black:
+```
+black .
+```

--- a/app/main.py
+++ b/app/main.py
@@ -1,0 +1,7 @@
+from fastapi import FastAPI
+
+app = FastAPI()
+
+@app.get("/status")
+def get_status():
+    return {"status": "ok"}

--- a/app/main.py
+++ b/app/main.py
@@ -1,7 +1,0 @@
-from fastapi import FastAPI
-
-app = FastAPI()
-
-@app.get("/status")
-def get_status():
-    return {"status": "ok"}

--- a/demo/classify_images_in_geoapi_project.py
+++ b/demo/classify_images_in_geoapi_project.py
@@ -13,7 +13,7 @@ from fontawesome import icons
 # Constants
 HAZMAPPER_BACKEND = "https://hazmapper.tacc.utexas.edu/geoapi-staging"
 PROJECT_ID = 204
-# Due to https://tacc-main.atlassian.net/issues/WG-384, need to also 
+# Due to https://tacc-main.atlassian.net/issues/WG-384, need to also
 # hardcode the original system of images as geoapi is unaware of those.
 ORIGINAL_SYSTEM = "project-7a8056ca-7c32-4456-9187-4452eaf0f9e7"
 CACHE_DIR = "cache_images/"
@@ -35,7 +35,9 @@ def get_fa_icon(icon_name):
 def get_unique_color(index, total_classes):
     """Return a unique color from a colormap."""
     cmap = plt.get_cmap("tab10")  # Discrete colormap with distinct colors
-    return "#{:02x}{:02x}{:02x}".format(*[int(255 * c) for c in cmap(index % total_classes)[:3]])
+    return "#{:02x}{:02x}{:02x}".format(
+        *[int(255 * c) for c in cmap(index % total_classes)[:3]]
+    )
 
 
 # Classifier
@@ -43,8 +45,10 @@ class ViTModel:
     """Encapsulates ViT model setup and image classification."""
 
     def __init__(self, model_name="google/vit-base-patch16-224"):
-        self.device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
-        self.model = ViTForImageClassification.from_pretrained(model_name).to(self.device)
+        self.device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+        self.model = ViTForImageClassification.from_pretrained(model_name).to(
+            self.device
+        )
         self.processor = ViTImageProcessor.from_pretrained(model_name)
 
     def classify_image(self, image):
@@ -62,9 +66,9 @@ def authenticate_tapis():
     username = input("Enter your username: ")
     password = getpass.getpass("Enter your password: ")
 
-    tapis = Tapis(base_url="https://designsafe.tapis.io",
-                  username=username,
-                  password=password)
+    tapis = Tapis(
+        base_url="https://designsafe.tapis.io", username=username, password=password
+    )
     tapis.get_tokens()
     return tapis, tapis.access_token.access_token
 
@@ -72,8 +76,10 @@ def authenticate_tapis():
 # Fetch project features
 def get_project_features(project_id, jwt):
     """Fetch project features from Hazmapper GeoAPI."""
-    response = requests.get(f"{HAZMAPPER_BACKEND}/projects/{project_id}/features/",
-                            headers={'X-Tapis-Token': jwt})
+    response = requests.get(
+        f"{HAZMAPPER_BACKEND}/projects/{project_id}/features/",
+        headers={"X-Tapis-Token": jwt},
+    )
     return response.json()
 
 
@@ -93,11 +99,13 @@ def get_image_file(tapis, system, path):
 
 
 # Update feature properties
-def update_feature_properties(project_id, feature_id, taggit_groups, taggit_tags, style, jwt):
+def update_feature_properties(
+    project_id, feature_id, taggit_groups, taggit_tags, style, jwt
+):
     """Update feature properties in Hazmapper GeoAPI."""
     url = f"{HAZMAPPER_BACKEND}/projects/{project_id}/features/{feature_id}/properties/"
     payload = {"taggit": {"groups": taggit_groups, "tags": taggit_tags}, "style": style}
-    response = requests.post(url, json=payload, headers={'X-Tapis-Token': jwt})
+    response = requests.post(url, json=payload, headers={"X-Tapis-Token": jwt})
     return response.json()
 
 
@@ -152,7 +160,7 @@ for i, class_label in enumerate(unique_class_labels):
         },
         "style": {
             "color": color,
-        }
+        },
     }
 
     # Add the icon to the group and style only if it's found
@@ -163,8 +171,7 @@ for i, class_label in enumerate(unique_class_labels):
 # Update features with styles
 for feature_id, class_label in feature_to_class_label.items():
     properties = class_to_taggit_properties_map[class_label]
-    update_feature_properties(PROJECT_ID,
-                              feature_id,
-                              [properties["group"]],
-                              [], properties["style"], jwt)
+    update_feature_properties(
+        PROJECT_ID, feature_id, [properties["group"]], [], properties["style"], jwt
+    )
     print(f"Updated feature {feature_id} with {properties}")

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,16 @@
+services:
+  imageinf:
+    build: .
+    container_name: imageinf
+    expose:
+      - "8000"
+
+  nginx:
+    image: nginx:alpine
+    container_name: imageinf_nginx
+    ports:
+      - "80:80"
+    volumes:
+      - ./local_conf/nginx.conf:/etc/nginx/nginx.conf:ro
+    depends_on:
+      - imageinf

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,6 +2,10 @@ services:
   imageinf:
     build: .
     container_name: imageinf
+    volumes:
+      - ./imageinf:/app/imageinf
+      - ./tests:/app/tests
+      - ./.flake8:/app/.flake8
     expose:
       - "8000"
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   imageinf:
-    build: .
+    image: taccaci/imageinf:local
     container_name: imageinf
     volumes:
       - ./imageinf:/app/imageinf

--- a/imageinf/main.py
+++ b/imageinf/main.py
@@ -1,0 +1,9 @@
+from fastapi import FastAPI
+from imageinf import status
+
+app = FastAPI(
+    title="imageInf API",
+    description="A simple image inference API",
+    version="0.1.0",
+)
+app.include_router(status.router)

--- a/imageinf/status.py
+++ b/imageinf/status.py
@@ -1,0 +1,13 @@
+from fastapi import APIRouter
+
+router = APIRouter(
+    prefix="/status",
+    tags=["Status"],
+)
+
+
+@router.get(
+    "", summary="Check service status", description="Returns 200 OK if the API is up."
+)
+def get_status():
+    return {"status": "ok"}

--- a/local_conf/nginx.conf
+++ b/local_conf/nginx.conf
@@ -1,0 +1,14 @@
+events {}
+
+http {
+    server {
+        listen 80;
+
+        location / {
+            proxy_pass http://imageinf:8000;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+        }
+    }
+}
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,6 @@
+fastapi
+uvicorn[standard]
+pytest
+httpx
+black
+flake8

--- a/tests/test_status.py
+++ b/tests/test_status.py
@@ -1,0 +1,10 @@
+from fastapi.testclient import TestClient
+from imageinf.main import app
+
+client = TestClient(app)
+
+
+def test_status():
+    response = client.get("/status")
+    assert response.status_code == 200
+    assert response.json() == {"status": "ok"}


### PR DESCRIPTION
## Overview

Add prototype fastapi app that has a status endpoint.  Follow on work will be in WIN-16.

## Related

* [WIN-4](https://tacc-main.atlassian.net/browse/WIN-4)

## Changes

* Add initial FastAPI skeleton with `/status` route
* Add `requirements.txt` (placeholder for future refinement)
* Add `Makefile` with `build`, `start`
* Add GitHub Actions workflow for test and lint checks

## Testing

1. Follow the instructions in the `README.md`
2. Confirm the app builds and runs via Docker
3. Visit `/status` to verify the endpoint returns a 200 with `{"status": "ok"}`
4. Hop on running container and run `make test` and `make lint` to confirm checks pass

