### PR TITLE
task/WIN-31: Update Makefile to use taccwma instead of taccaci for image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .PHONY: build deploy start stop
 
 TAG := $(shell git log --format=%h -1)
-IMAGE=taccaci/imageinf
+IMAGE=taccwma/imageinf
 
 build:
 	docker build -t $(IMAGE):$(TAG) .


### PR DESCRIPTION
## Overview

Update Makefile so image uses `taccwma` instead of `taccaci`.  

Note:
* Makefile already existed. 
* https://jenkins.portals.tacc.utexas.edu/job/Imageinf%20Build%20Image/ is the jenkins job
* Its ran with the old `taccaci` so we need to merge this and then the job will run again. 

## Related

* [WIN-31](https://tacc-main.atlassian.net/browse/WIN-31)
