### PR TITLE
task/WG-625: use cpu-only pytorch for current deployment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,8 +9,13 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
+# Use CPU-only PyTorch by default. For GPU support, build with:
+#   docker build --build-arg TORCH_INDEX=https://download.pytorch.org/whl/cu121 ...
+ARG TORCH_INDEX=https://download.pytorch.org/whl/cpu
+
 COPY requirements.txt .
-RUN pip install --no-cache-dir -r requirements.txt
+RUN pip install --no-cache-dir --extra-index-url ${TORCH_INDEX} -r requirements.txt
+
 
 WORKDIR /app
 


### PR DESCRIPTION
## Overview

Use CPU-only PyTorch by default to reduce image size

PyTorch installs CUDA bundles on amd64 Linux, which inflates the image size from ~1GB to 4-7GB.

In our demo service we are only using CPU.  So okay to only have cpu-only approach.  We will look at this again when building images for workers using GPUs

## Related

* [WG-625](https://tacc-main.atlassian.net/browse/WG-625)

